### PR TITLE
Add license and attribution footer to lecture slides

### DIFF
--- a/lectures/foot.html
+++ b/lectures/foot.html
@@ -2,6 +2,16 @@
 
     </div>  <!-- reveal -->
 
+        <footer class="slide-footer">
+            GIS/MEA582: Geospatial Modeling and Analysis
+            <span class="sep">|</span>
+            &copy; 2008&ndash;2026
+            <a href="https://creativecommons.org/licenses/by-sa/4.0/">CC BY-SA 4.0</a>
+            <span class="sep">|</span>
+            <a href="https://geospatial.ncsu.edu/geoforall/">NCSU GeoForAll Lab</a>,
+            <a href="https://geospatial.ncsu.edu/">Center for Geospatial Analytics</a>
+        </footer>
+
         <script src="lib/js/head.min.js"></script>
         <script src="js/reveal.js"></script>
 

--- a/lectures/head.html
+++ b/lectures/head.html
@@ -162,6 +162,24 @@
             z-index: 30;
             font-size: medium !important;
         }
+        .slide-footer {
+            position: fixed;
+            bottom: 8px;
+            left: 0;
+            right: 0;
+            z-index: 30;
+            font-size: 12px;
+            color: gray;
+            text-align: center;
+            line-height: 1.2;
+        }
+        .slide-footer a {
+            color: #060 !important;
+        }
+        .slide-footer .sep {
+            margin: 0 0.4em;
+            color: #bbb;
+        }
         </style>
     </head>
 


### PR DESCRIPTION
## Summary

Adds a persistent footer to all lecture slide decks containing the course name, copyright/CC BY-SA 4.0 license, and Center for Geospatial Analytics / NCSU GeoForAll Lab attribution — mirroring the footer already present on the course web pages.

Closes #50.

## Changes

- `lectures/head.html` — adds `.slide-footer` CSS rules (position: fixed; bottom: 8px; centered; gray 12px text with green `#060` links matching the existing color scheme).
- `lectures/foot.html` — inserts a `<footer class="slide-footer">` element after the reveal container, listing course name, copyright range, CC BY-SA 4.0 link, and Center/GeoForAll Lab links.

The attribution mirrors the existing top-level `foot.html` used for the course web pages, condensed for a slide-deck context.

## Test plan

- [x] Built all slide decks with `cd lectures && ./build.sh` (no errors).
- [x] Served `build/lectures/` with a local HTTP server and visually verified the footer renders correctly on multiple slide decks (about.html, geospatialdata.html) and persists across slides.
- [x] Confirmed the footer does not overlap with the Reveal.js progress bar (positioned at the very bottom edge) or the chalkboard plugin icons (positioned at bottom-left).
- [ ] PDF print export verification (`?print-pdf`) — not tested locally; `position: fixed` may render the footer only on the first PDF page. Happy to adjust to `position: absolute` or scope to a `@media print` rule if you'd prefer a different print behavior.

## Screenshot

Footer visible at the bottom of an example slide:

> `GIS/MEA582: Geospatial Modeling and Analysis  |  © 2008–2026  CC BY-SA 4.0  |  NCSU GeoForAll Lab, Center for Geospatial Analytics`